### PR TITLE
Add game counting logic, add new methods to group games, add dataclass representing a single quake game

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-export PYTHONPATH="$PYTHONPATH:$PWD"

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# Ignore VSCode settings
-.vscode/
-
-
 # Ignore .pytest_cache
 .pytest_cache
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,5 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,28 @@
+{
+    "python.testing.pytestArgs": [
+        "--no-cov"
+    ],
+    "[python]": {
+        "diffEditor.ignoreTrimWhitespace": false,
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.formatOnSave": true,
+        "editor.wordBasedSuggestions": "allDocuments",
+        "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit"
+        },
+    },
+    "ruff.enable": true,
+    "ruff.nativeServer": true,
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "terminal.integrated.env.linux": {
+        "PYTHONPATH": "${workspaceFolder}"
+    },
+    "terminal.integrated.env.windows": {
+        "PYTHONPATH": "${workspaceFolder}"
+    },
+    "terminal.integrated.env.osx": {
+        "PYTHONPATH": "${workspaceFolder}"
+    }
+}

--- a/src/dclasses/__init__.py
+++ b/src/dclasses/__init__.py
@@ -1,0 +1,3 @@
+from .quake_log import QuakeLog
+
+__all__ = ["QuakeLog"]

--- a/src/dclasses/quake_log.py
+++ b/src/dclasses/quake_log.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class QuakeLog:
+    game_id: int
+    players: list[str] = field(default_factory=list)
+    kills: dict[str, int] = field(default_factory=dict)
+    world_kill_count: int = 0
+
+    def __dict__(self) -> str:
+        return {
+            f"game_{self.game_id}": {
+                "total_kills": sum(self.kills.values()),
+                "players": self.players,
+                "kills": self.kills,
+                "world_kill_count": self.world_kill_count,
+            }
+        }

--- a/src/parser/__init__.py
+++ b/src/parser/__init__.py
@@ -1,7 +1,4 @@
-from .log_parser import QuakeLogParser
 from .base_parser import AbstractLogParser
+from .log_parser import QuakeLog, QuakeLogParser
 
-__all__ = [
-    'QuakeLogParser',
-    'AbstractLogParser',
-]
+__all__ = ["QuakeLogParser", "AbstractLogParser", "QuakeLog"]

--- a/src/parser/log_parser.py
+++ b/src/parser/log_parser.py
@@ -1,4 +1,5 @@
 import re
+from src.dclasses import QuakeLog
 
 from src.enums import QuakeDeathCause
 
@@ -13,9 +14,8 @@ class QuakeLogParser(AbstractLogParser):
     def __init__(self, log_file_path):
         self.log_file_path = log_file_path
         self.log_file = open(log_file_path, "r")
-        self.game_count = 0
-        self.games = []
-        self.current_game = False
+        self.games: list[QuakeLog] = []
+        self.current_game: QuakeLog | None = None
 
     def _line_parser(self):
         with open(self.log_file_path, "r") as log_file:
@@ -26,16 +26,23 @@ class QuakeLogParser(AbstractLogParser):
         for line in self._line_parser():
             self._count_games(line)
 
-        return {"game_count": self.game_count}
+        return {"game_count": len(self.games)}
 
     def match_death_cause(self, log_line):
         pass
 
     def _count_games(self, line):
         if re.search(r"InitGame", line):
-            self.current_game = True
+            self._start_new_game()
         elif re.search(r"ShutdownGame", line) and self.current_game:
-            self.game_count += 1
-            self.current_game = False
+            self._end_current_game()
+
+    def _start_new_game(self):
+        self.current_game = QuakeLog(game_id=len(self.games) + 1)
+
+    def _end_current_game(self):
+        if self.current_game:
+            self.games.append(self.current_game)
+            self.current_game = None
 
     def _get_world_kill_count(self): ...

--- a/src/parser/log_parser.py
+++ b/src/parser/log_parser.py
@@ -1,4 +1,8 @@
-from .base_parser import AbstractLogParser, QuakeDeathCause
+import re
+
+from src.enums import QuakeDeathCause
+
+from .base_parser import AbstractLogParser
 
 
 class QuakeLogParser(AbstractLogParser):
@@ -8,13 +12,30 @@ class QuakeLogParser(AbstractLogParser):
 
     def __init__(self, log_file_path):
         self.log_file_path = log_file_path
-        self.log_file = open(log_file_path, 'r')
+        self.log_file = open(log_file_path, "r")
+        self.game_count = 0
+        self.games = []
+        self.current_game = False
 
-    def _line_parser(self, line):
-        return super()._line_parser(line)
+    def _line_parser(self):
+        with open(self.log_file_path, "r") as log_file:
+            for line in log_file:
+                yield line.strip()
 
     def parse(self):
-        return super().parse()
+        for line in self._line_parser():
+            self._count_games(line)
+
+        return {"game_count": self.game_count}
 
     def match_death_cause(self, log_line):
         pass
+
+    def _count_games(self, line):
+        if re.search(r"InitGame", line):
+            self.current_game = True
+        elif re.search(r"ShutdownGame", line) and self.current_game:
+            self.game_count += 1
+            self.current_game = False
+
+    def _get_world_kill_count(self): ...

--- a/src/parser/log_parser.py
+++ b/src/parser/log_parser.py
@@ -26,7 +26,15 @@ class QuakeLogParser(AbstractLogParser):
         for line in self._line_parser():
             self._count_games(line)
 
-        return {"game_count": len(self.games)}
+        return self._group_game_results()
+
+    def _group_game_results(self):
+        parsed_games = []
+        for game in self.games:
+            game_result = game.__dict__()
+            parsed_games.append(game_result)
+
+        return parsed_games
 
     def match_death_cause(self, log_line):
         pass
@@ -44,5 +52,3 @@ class QuakeLogParser(AbstractLogParser):
         if self.current_game:
             self.games.append(self.current_game)
             self.current_game = None
-
-    def _get_world_kill_count(self): ...

--- a/tests/fixtures/qlog_shard_1.log
+++ b/tests/fixtures/qlog_shard_1.log
@@ -1,0 +1,79 @@
+0:00 ------------------------------------------------------------
+0:00 InitGame: \sv_floodProtect\1\sv_maxPing\0\sv_minPing\0\sv_maxRate\10000\sv_minRate\0\sv_hostname\Code Miner Server\g_gametype\0\sv_privateClients\2\sv_maxclients\16\sv_allowDownload\0\dmflags\0\fraglimit\20\timelimit\15\g_maxGameClients\0\capturelimit\8\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\q3dm17\gamename\baseq3\g_needpass\0
+15:00 Exit: Timelimit hit.
+20:34 ClientConnect: 2
+20:34 ClientUserinfoChanged: 2 n\Isgalamido\t\0\model\xian/default\hmodel\xian/default\g_redteam\\g_blueteam\\c1\4\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+20:37 ClientUserinfoChanged: 2 n\Isgalamido\t\0\model\uriel/zael\hmodel\uriel/zael\g_redteam\\g_blueteam\\c1\5\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+20:37 ClientBegin: 2
+20:37 ShutdownGame:
+20:37 ------------------------------------------------------------
+20:37 ------------------------------------------------------------
+20:37 InitGame: \sv_floodProtect\1\sv_maxPing\0\sv_minPing\0\sv_maxRate\10000\sv_minRate\0\sv_hostname\Code Miner Server\g_gametype\0\sv_privateClients\2\sv_maxclients\16\sv_allowDownload\0\bot_minplayers\0\dmflags\0\fraglimit\20\timelimit\15\g_maxGameClients\0\capturelimit\8\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\q3dm17\gamename\baseq3\g_needpass\0
+20:38 ClientConnect: 2
+20:38 ClientUserinfoChanged: 2 n\Isgalamido\t\0\model\uriel/zael\hmodel\uriel/zael\g_redteam\\g_blueteam\\c1\5\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+20:38 ClientBegin: 2
+20:40 Item: 2 weapon_rocketlauncher
+20:40 Item: 2 ammo_rockets
+20:46 ShutdownGame:
+0:00 ------------------------------------------------------------
+0:00 InitGame: \sv_floodProtect\1\sv_maxPing\0\sv_minPing\0\sv_maxRate\10000\sv_minRate\0\sv_hostname\Code Miner Server\g_gametype\0\sv_privateClients\2\sv_maxclients\16\sv_allowDownload\0\dmflags\0\fraglimit\20\timelimit\15\g_maxGameClients\0\capturelimit\8\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\q3dm17\gamename\baseq3\g_needpass\0
+0:25 ClientConnect: 2
+0:25 ClientUserinfoChanged: 2 n\Dono da Bola\t\0\model\sarge/krusade\hmodel\sarge/krusade\g_redteam\\g_blueteam\\c1\5\c2\5\hc\95\w\0\l\0\tt\0\tl\0
+0:27 ClientUserinfoChanged: 2 n\Mocinha\t\0\model\sarge\hmodel\sarge\g_redteam\\g_blueteam\\c1\4\c2\5\hc\95\w\0\l\0\tt\0\tl\0
+1:47 Item: 2 item_armor_shard
+1:47 ShutdownGame:
+ 16:53 InitGame: \capturelimit\8\g_maxGameClients\0\timelimit\15\fraglimit\20\dmflags\0\bot_minplayers\0\sv_allowDownload\0\sv_maxclients\16\sv_privateClients\2\g_gametype\4\sv_hostname\Code Miner Server\sv_minRate\0\sv_maxRate\10000\sv_minPing\0\sv_maxPing\0\sv_floodProtect\1\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\Q3TOURNEY6_CTF\gamename\baseq3\g_needpass\0
+ 16:53 ClientConnect: 4
+ 16:53 ClientUserinfoChanged: 4 n\Zeh\t\2\model\sarge/default\hmodel\sarge/default\g_redteam\\g_blueteam\\c1\1\c2\5\hc\100\w\0\l\0\tt\0\tl\1
+ 16:53 ClientBegin: 4
+ 16:53 ClientConnect: 7
+ 16:53 ClientUserinfoChanged: 7 n\Assasinu Credi\t\1\model\james\hmodel\*james\g_redteam\\g_blueteam\\c1\4\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+ 16:53 ClientBegin: 7
+ 16:56 Item: 4 weapon_railgun
+ 16:58 Item: 4 item_armor_body
+ 17:06 Item: 4 weapon_railgun
+ 17:16 Kill: 1022 4 22: <world> killed Zeh by MOD_TRIGGER_HURT
+ 17:19 Item: 4 weapon_railgun
+ 17:25 Item: 4 team_CTF_redflag
+ 17:28 Kill: 1022 4 22: <world> killed Zeh by MOD_TRIGGER_HURT
+ 17:31 Item: 4 ammo_rockets
+ 17:31 Item: 4 ammo_bullets
+ 17:32 Item: 4 weapon_rocketlauncher
+ 17:35 ClientDisconnect: 7
+ 17:35 Item: 4 team_CTF_redflag
+ 17:37 Item: 4 ammo_rockets
+ 17:37 Item: 4 ammo_bullets
+ 17:38 Item: 4 weapon_rocketlauncher
+ 17:41 Item: 4 team_CTF_blueflag
+ 17:43 Item: 4 weapon_rocketlauncher
+ 17:48 Kill: 1022 4 22: <world> killed Zeh by MOD_TRIGGER_HURT
+ 17:50 ClientDisconnect: 4
+ 31:53 Exit: Timelimit hit.
+ 31:53 red:0  blue:1
+981:06 ClientConnect: 2
+981:06 ClientUserinfoChanged: 2 n\Dono da Bola\t\3\model\sarge/krusade\hmodel\sarge/krusade\g_redteam\\g_blueteam\\c1\5\c2\5\hc\95\w\0\l\0\tt\0\tl\0
+981:08 ClientUserinfoChanged: 2 n\Dono da Bola\t\3\model\sarge\hmodel\sarge\g_redteam\\g_blueteam\\c1\4\c2\5\hc\95\w\0\l\0\tt\0\tl\0
+981:08 ClientBegin: 2
+981:11 ClientConnect: 3
+981:11 ClientUserinfoChanged: 3 n\Fasano Again\t\3\model\razor/id\hmodel\razor/id\g_redteam\\g_blueteam\\c1\3\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+981:13 ClientConnect: 4
+981:13 ClientUserinfoChanged: 4 n\Isgalamido\t\3\model\xian/default\hmodel\xian/default\g_redteam\\g_blueteam\\c1\4\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+981:14 ClientUserinfoChanged: 3 n\Oootsimo\t\3\model\razor/id\hmodel\razor/id\g_redteam\\g_blueteam\\c1\3\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+981:14 ClientBegin: 3
+981:17 ClientUserinfoChanged: 4 n\Isgalamido\t\3\model\uriel/zael\hmodel\uriel/zael\g_redteam\\g_blueteam\\c1\5\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+981:17 ClientBegin: 4
+981:19 ClientConnect: 5
+981:19 ClientUserinfoChanged: 5 n\Assasinu Credi\t\3\model\james\hmodel\*james\g_redteam\\g_blueteam\\c1\4\c2\5\hc\95\w\0\l\0\tt\0\tl\0
+981:21 say: Oootsimo: team red
+981:22 ClientUserinfoChanged: 5 n\Assasinu Credi\t\3\model\james\hmodel\*james\g_redteam\\g_blueteam\\c1\4\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+981:22 ClientBegin: 5
+981:26 say: Isgalamido: team blue
+981:27 ShutdownGame:
+981:27 ------------------------------------------------------------
+981:27 ------------------------------------------------------------
+981:27 InitGame: \capturelimit\8\g_maxGameClients\0\timelimit\15\fraglimit\20\dmflags\0\bot_minplayers\0\sv_allowDownload\0\sv_maxclients\16\sv_privateClients\2\g_gametype\4\sv_hostname\Code Miner Server\sv_minRate\0\sv_maxRate\10000\sv_minPing\0\sv_maxPing\0\sv_floodProtect\1\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\Q3TOURNEY6_CTF\gamename\baseq3\g_needpass\0
+981:27 ClientConnect: 2
+981:27 ClientUserinfoChanged: 2 n\Dono da Bola\t\3\model\sarge\hmodel\sarge\g_redteam\\g_blueteam\\c1\4\c2\5\hc\95\w\0\l\0\tt\0\tl\0
+981:27 ClientBegin: 2
+981:27 ClientConnect: 3
+981:27 ShutdownGame:

--- a/tests/fixtures/qlog_shard_2.log
+++ b/tests/fixtures/qlog_shard_2.log
@@ -1,0 +1,47 @@
+0:00 ------------------------------------------------------------
+0:00 InitGame: \sv_floodProtect\1\sv_maxPing\0\sv_minPing\0\sv_maxRate\10000\sv_minRate\0\sv_hostname\Code Miner Server\g_gametype\0\sv_privateClients\2\sv_maxclients\16\sv_allowDownload\0\dmflags\0\fraglimit\20\timelimit\15\g_maxGameClients\0\capturelimit\8\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\q3dm17\gamename\baseq3\g_needpass\0
+15:00 Exit: Timelimit hit.
+20:34 ClientConnect: 2
+20:34 ClientUserinfoChanged: 2 n\Isgalamido\t\0\model\xian/default\hmodel\xian/default\g_redteam\\g_blueteam\\c1\4\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+20:37 ClientUserinfoChanged: 2 n\Isgalamido\t\0\model\uriel/zael\hmodel\uriel/zael\g_redteam\\g_blueteam\\c1\5\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+20:37 ClientBegin: 2
+20:37 ShutdownGame:
+20:37 ------------------------------------------------------------
+20:37 ------------------------------------------------------------
+20:37 InitGame: \sv_floodProtect\1\sv_maxPing\0\sv_minPing\0\sv_maxRate\10000\sv_minRate\0\sv_hostname\Code Miner Server\g_gametype\0\sv_privateClients\2\sv_maxclients\16\sv_allowDownload\0\bot_minplayers\0\dmflags\0\fraglimit\20\timelimit\15\g_maxGameClients\0\capturelimit\8\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\q3dm17\gamename\baseq3\g_needpass\0
+20:38 ClientConnect: 2
+20:38 ClientUserinfoChanged: 2 n\Isgalamido\t\0\model\uriel/zael\hmodel\uriel/zael\g_redteam\\g_blueteam\\c1\5\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+20:38 ClientBegin: 2
+20:40 Item: 2 weapon_rocketlauncher
+20:40 Item: 2 ammo_rockets
+20:46 ShutdownGame:
+0:00 ------------------------------------------------------------
+0:00 InitGame: \sv_floodProtect\1\sv_maxPing\0\sv_minPing\0\sv_maxRate\10000\sv_minRate\0\sv_hostname\Code Miner Server\g_gametype\0\sv_privateClients\2\sv_maxclients\16\sv_allowDownload\0\dmflags\0\fraglimit\20\timelimit\15\g_maxGameClients\0\capturelimit\8\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\q3dm17\gamename\baseq3\g_needpass\0
+0:25 ClientConnect: 2
+0:25 ClientUserinfoChanged: 2 n\Dono da Bola\t\0\model\sarge/krusade\hmodel\sarge/krusade\g_redteam\\g_blueteam\\c1\5\c2\5\hc\95\w\0\l\0\tt\0\tl\0
+0:27 ClientUserinfoChanged: 2 n\Mocinha\t\0\model\sarge\hmodel\sarge\g_redteam\\g_blueteam\\c1\4\c2\5\hc\95\w\0\l\0\tt\0\tl\0
+1:47 Item: 2 item_armor_shard
+1:47 ShutdownGame:
+981:27 InitGame: \capturelimit\8\g_maxGameClients\0\timelimit\15\fraglimit\20\dmflags\0\bot_minplayers\0\sv_allowDownload\0\sv_maxclients\16\sv_privateClients\2\g_gametype\4\sv_hostname\Code Miner Server\sv_minRate\0\sv_maxRate\10000\sv_minPing\0\sv_maxPing\0\sv_floodProtect\1\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\Q3TOURNEY6_CTF\gamename\baseq3\g_needpass\0
+981:27 ClientConnect: 2
+981:27 ClientUserinfoChanged: 2 n\Dono da Bola\t\3\model\sarge\hmodel\sarge\g_redteam\\g_blueteam\\c1\4\c2\5\hc\95\w\0\l\0\tt\0\tl\0
+981:27 ClientBegin: 2
+981:27 ClientConnect: 3
+981:27 ClientUserinfoChanged: 3 n\Oootsimo\t\3\model\razor/id\hmodel\razor/id\g_redteam\\g_blueteam\\c1\3\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+981:27 ClientBegin: 3
+981:27 ClientConnect: 4
+981:27 ClientUserinfoChanged: 4 n\Isgalamido\t\3\model\uriel/zael\hmodel\uriel/zael\g_redteam\\g_blueteam\\c1\5\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+981:27 ClientBegin: 4
+981:27 ClientConnect: 5
+981:27 ClientUserinfoChanged:
+981:33 Item: 4 weapon_railgun
+981:34 ClientUserinfoChanged: 3 n\Oootsimo\t\2\model\razor/id\hmodel\razor/id\g_redteam\\g_blueteam\\c1\3\c2\5\hc\100\w\0\l\0\tt\0\tl\1
+981:34 ClientUserinfoChanged: 3 n\Oootsimo\t\2\model\razor/id\hmodel\razor/id\g_redteam\\g_blueteam\\c1\3\c2\5\hc\100\w\0\l\0\tt\0\tl\1
+981:34 ClientBegin: 3
+981:35 Item: 4 weapon_rocketlauncher
+981:36 Item: 3 weapon_railgun
+981:36 ClientConnect: 6
+981:36 ClientUserinfoChanged: 6 n\Zeh\t\3\model\sarge/default\hmodel\sarge/default\g_redteam\\g_blueteam\\c1\5\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+981:39 ClientUserinfoChanged: 6 n\Zeh\t\3\model\sarge/default\hmodel\sarge/default\g_redteam\\g_blueteam\\c1\1\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+981:39 ClientBegin: 6
+981:39 ShutdownGame:

--- a/tests/fixtures/qlog_shard_3.log
+++ b/tests/fixtures/qlog_shard_3.log
@@ -1,0 +1,72 @@
+0:00 ------------------------------------------------------------
+0:00 InitGame: \sv_floodProtect\1\sv_maxPing\0\sv_minPing\0\sv_maxRate\10000\sv_minRate\0\sv_hostname\Code Miner Server\g_gametype\0\sv_privateClients\2\sv_maxclients\16\sv_allowDownload\0\dmflags\0\fraglimit\20\timelimit\15\g_maxGameClients\0\capturelimit\8\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\q3dm17\gamename\baseq3\g_needpass\0
+15:00 Exit: Timelimit hit.
+20:34 ClientConnect: 2
+20:34 ClientUserinfoChanged: 2 n\Isgalamido\t\0\model\xian/default\hmodel\xian/default\g_redteam\\g_blueteam\\c1\4\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+20:37 ClientUserinfoChanged: 2 n\Isgalamido\t\0\model\uriel/zael\hmodel\uriel/zael\g_redteam\\g_blueteam\\c1\5\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+20:37 ClientBegin: 2
+20:37 ShutdownGame:
+20:37 ------------------------------------------------------------
+20:37 ------------------------------------------------------------
+20:37 InitGame: \sv_floodProtect\1\sv_maxPing\0\sv_minPing\0\sv_maxRate\10000\sv_minRate\0\sv_hostname\Code Miner Server\g_gametype\0\sv_privateClients\2\sv_maxclients\16\sv_allowDownload\0\bot_minplayers\0\dmflags\0\fraglimit\20\timelimit\15\g_maxGameClients\0\capturelimit\8\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\q3dm17\gamename\baseq3\g_needpass\0
+20:38 ClientConnect: 2
+20:38 ClientUserinfoChanged: 2 n\Isgalamido\t\0\model\uriel/zael\hmodel\uriel/zael\g_redteam\\g_blueteam\\c1\5\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+20:38 ClientBegin: 2
+20:40 Item: 2 weapon_rocketlauncher
+20:40 Item: 2 ammo_rockets
+20:46 ShutdownGame:
+0:00 ------------------------------------------------------------
+0:00 InitGame: \sv_floodProtect\1\sv_maxPing\0\sv_minPing\0\sv_maxRate\10000\sv_minRate\0\sv_hostname\Code Miner Server\g_gametype\0\sv_privateClients\2\sv_maxclients\16\sv_allowDownload\0\dmflags\0\fraglimit\20\timelimit\15\g_maxGameClients\0\capturelimit\8\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\q3dm17\gamename\baseq3\g_needpass\0
+0:25 ClientConnect: 2
+0:25 ClientUserinfoChanged: 2 n\Dono da Bola\t\0\model\sarge/krusade\hmodel\sarge/krusade\g_redteam\\g_blueteam\\c1\5\c2\5\hc\95\w\0\l\0\tt\0\tl\0
+0:27 ClientUserinfoChanged: 2 n\Mocinha\t\0\model\sarge\hmodel\sarge\g_redteam\\g_blueteam\\c1\4\c2\5\hc\95\w\0\l\0\tt\0\tl\0
+1:47 Item: 2 item_armor_shard
+1:47 ShutdownGame:
+e: 2  ping: 14  client: 7 Mal
+  6:10 ------------------------------------------------------------
+  6:10 InitGame: \capturelimit\8\g_maxGameClients\0\timelimit\15\fraglimit\20\dmflags\0\bot_minplayers\0\sv_allowDownload\0\sv_maxclients\16\sv_privateClients\2\g_gametype\= 0\sv_hostname\Code Miner Server\sv_minRate\0\sv_maxRate\10000\sv_minPing\0\sv_maxPing\0\sv_floodProtect\1\version\ioq3 1.36 linux-x86_64 Apr 12 2009\protocol\68\mapname\q3dm17\gamename\baseq3\g_needpass\0
+  6:10 ClientConnect: 2
+  6:10 ClientUserinfoChanged: 2 n\Isgalamido\t\0\model\uriel/zael\hmodel\uriel/zael\g_redteam\\g_blueteam\\c1\5\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+  6:10 ClientBegin: 2
+  6:10 ClientConnect: 3
+  6:10 ClientUserinfoChanged: 3 n\Oootsimo\t\0\model\razor/id\hmodel\razor/id\g_redteam\\g_blueteam\\c1\3\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+  6:10 ClientBegin: 3
+  6:10 ClientConnect: 4
+  6:10 ClientUserinfoChanged: 4 n\Dono da Bola\t\0\model\sarge\hmodel\sarge\g_redteam\\g_blueteam\\c1\4\c2\5\hc\95\w\0\l\0\tt\0\tl\0
+  6:10 ClientBegin: 4
+  6:10 ClientConnect: 5
+  6:10 ClientUserinfoChanged: 5 n\Assasinu Credi\t\0\model\sarge\hmodel\sarge\g_redteam\\g_blueteam\\c1\4\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+  6:10 ClientBegin: 5
+  6:10 ClientConnect: 6
+  6:10 ClientUserinfoChanged: 6 n\Zeh\t\0\model\sarge/default\hmodel\sarge/default\g_redteam\\g_blueteam\\c1\1\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+  6:10 ClientBegin: 6
+  6:10 ClientConnect: 7
+  6:10 ClientUserinfoChanged: 7 n\Mal\t\0\model\sarge\hmodel\sarge\g_redteam\\g_blueteam\\c1\4\c2\5\hc\100\w\0\l\0\tt\0\tl\0
+  6:10 ClientBegin: 7
+  6:12 Item: 5 ammo_rockets
+  6:12 Item: 4 weapon_rocketlauncher
+  6:12 Item: 5 weapon_rocketlauncher
+  6:15 Item: 3 item_armor_body
+  6:17 Kill: 4 6 7: Dono da Bola killed Zeh by MOD_ROCKET_SPLASH
+  6:18 Item: 7 weapon_rocketlauncher
+  6:18 Item: 3 ammo_rockets
+  6:19 Item: 2 weapon_railgun
+  6:22 Item: 5 item_health_large
+  6:22 Item: 2 weapon_railgun
+  6:22 Kill: 4 4 7: Dono da Bola killed Dono da Bola by MOD_ROCKET_SPLASH
+  6:23 Item: 7 weapon_rocketlauncher
+  6:25 Item: 3 weapon_shotgun
+  6:25 Item: 2 weapon_railgun
+  6:26 Item: 4 weapon_rocketlauncher
+  6:27 Item: 3 weapon_rocketlauncher
+  6:29 Item: 4 item_armor_shard
+  6:29 Item: 4 item_armor_shard
+  6:29 Item: 4 item_armor_shard
+  6:30 Item: 4 item_armor_combat
+  6:30 Kill: 3 5 6: Oootsimo killed Assasinu Credi by MOD_ROCKET
+  6:31 Item: 2 weapon_railgun
+  6:31 Item: 7 weapon_rocketlauncher
+  6:34 Item: 2 weapon_railgun
+  6:34 ShutdownGame:
+  6:34 ------------------------------------------------------------
+  6:34 ------------------------------------------------------------

--- a/tests/test_games_grouped.py
+++ b/tests/test_games_grouped.py
@@ -1,0 +1,45 @@
+import pytest
+
+from src.parser import QuakeLogParser
+from src.dclasses import QuakeLog
+
+@pytest.fixture
+def create_mock_log_file(tmp_path):
+    def _create_file(content):
+        file_path = tmp_path / "test.log"
+        file_path.write_text(content)
+        return file_path
+
+    return _create_file
+
+
+@pytest.fixture(
+    params=[
+        ("tests/fixtures/qlog_shard_1.log", 5),
+        ("tests/fixtures/qlog_shard_2.log", 4),
+        ("tests/fixtures/qlog_shard_3.log", 4),
+    ]
+)
+# For each test file, we expect a different number of games
+def log_file_fixture(request):
+    file_path, expected_game_count = request.param
+    with open(file_path, "r") as f:
+        content = f.read()
+    return content, expected_game_count
+
+
+def test_parse_games_grouped(create_mock_log_file, log_file_fixture):
+    # Arrange
+    log_content, expected_game_count = log_file_fixture
+    mock_file = create_mock_log_file(log_content)
+    log_parser = QuakeLogParser(mock_file)
+    log_parser.parse()
+
+    # Act
+    parsed_games = log_parser._group_game_results()
+
+    # Assert
+    assert len(parsed_games) == expected_game_count
+    assert len(log_parser.games) == expected_game_count
+    # For each game in the parsed games, verify that the format is correct
+    assert all(isinstance(game, QuakeLog) for game in log_parser.games)

--- a/tests/test_log_file.py
+++ b/tests/test_log_file.py
@@ -1,0 +1,62 @@
+import pytest
+from src.parser import QuakeLogParser
+
+@pytest.fixture
+def create_mock_log_file(tmp_path):
+    def _create_file(content):
+        file_path = tmp_path / "test.log"
+        file_path.write_text(content)
+        return file_path
+    return _create_file
+
+@pytest.mark.parametrize("initial_state, command, expected_count, expected_state", [
+    (False, "InitGame", 0, True),
+    (True, "InitGame", 0, True),
+    (False, "ShutdownGame", 0, False),
+    (True, "ShutdownGame", 1, False),
+])
+def test_count_games(create_mock_log_file, initial_state, command, expected_count, expected_state):
+    log_content = f"0:00 {command}:\n"
+    mock_file = create_mock_log_file(log_content)
+    parser = QuakeLogParser(mock_file)
+    parser.current_game = initial_state
+
+    parser._count_games(command)
+
+    assert parser.game_count == expected_count
+    assert parser.current_game == expected_state
+
+@pytest.mark.parametrize("log_content, expected_game_count, expected_final_state", [
+    ("""
+    0:00 InitGame:
+    15:00 ShutdownGame:
+    """, 1, False),
+    ("""
+    0:00 InitGame:
+    15:00 ShutdownGame:
+    20:00 InitGame:
+    """, 1, True),
+    ("""
+    0:00 InitGame:
+    15:00 ShutdownGame:
+    20:00 InitGame:
+    25:00 ShutdownGame:
+    """, 2, False),
+    ("""
+    0:00 InitGame:
+    15:00 Exit: Timelimit hit.
+    20:00 ShutdownGame:
+    25:00 InitGame:
+    30:00 Exit: Fraglimit hit.
+    35:00 ShutdownGame:
+    """, 2, False),
+    ("", 0, False),
+])
+def test_parse_log_file(create_mock_log_file, log_content, expected_game_count, expected_final_state):
+    mock_file = create_mock_log_file(log_content)
+    parser = QuakeLogParser(mock_file)
+
+    result = parser.parse()
+
+    assert result["game_count"] == expected_game_count
+    assert parser.current_game == expected_final_state

--- a/tests/test_log_file.py
+++ b/tests/test_log_file.py
@@ -1,5 +1,8 @@
 import pytest
+
+from src.dclasses.quake_log import QuakeLog
 from src.parser import QuakeLogParser
+
 
 @pytest.fixture
 def create_mock_log_file(tmp_path):
@@ -7,56 +10,85 @@ def create_mock_log_file(tmp_path):
         file_path = tmp_path / "test.log"
         file_path.write_text(content)
         return file_path
+
     return _create_file
 
-@pytest.mark.parametrize("initial_state, command, expected_count, expected_state", [
-    (False, "InitGame", 0, True),
-    (True, "InitGame", 0, True),
-    (False, "ShutdownGame", 0, False),
-    (True, "ShutdownGame", 1, False),
-])
-def test_count_games(create_mock_log_file, initial_state, command, expected_count, expected_state):
+
+@pytest.mark.parametrize(
+    "initial_state, command, expected_count, expected_state",
+    [
+        (False, "InitGame", 0, True),
+        (True, "InitGame", 0, True),
+        (False, "ShutdownGame", 0, False),
+        (True, "ShutdownGame", 1, False),
+    ],
+)
+def test_count_games(
+    create_mock_log_file, initial_state, command, expected_count, expected_state
+):
     log_content = f"0:00 {command}:\n"
     mock_file = create_mock_log_file(log_content)
     parser = QuakeLogParser(mock_file)
-    parser.current_game = initial_state
+    parser._start_new_game() if initial_state else None
 
     parser._count_games(command)
 
-    assert parser.game_count == expected_count
-    assert parser.current_game == expected_state
+    assert len(parser.games) == expected_count
+    assert isinstance(parser.current_game, QuakeLog) == expected_state
 
-@pytest.mark.parametrize("log_content, expected_game_count, expected_final_state", [
-    ("""
+
+@pytest.mark.parametrize(
+    "log_content, expected_game_count, expected_final_state",
+    [
+        (
+            """
     0:00 InitGame:
     15:00 ShutdownGame:
-    """, 1, False),
-    ("""
+    """,
+            1,
+            False,
+        ),
+        (
+            """
     0:00 InitGame:
     15:00 ShutdownGame:
     20:00 InitGame:
-    """, 1, True),
-    ("""
+    """,
+            1,
+            True,
+        ),
+        (
+            """
     0:00 InitGame:
     15:00 ShutdownGame:
     20:00 InitGame:
     25:00 ShutdownGame:
-    """, 2, False),
-    ("""
+    """,
+            2,
+            False,
+        ),
+        (
+            """
     0:00 InitGame:
     15:00 Exit: Timelimit hit.
     20:00 ShutdownGame:
     25:00 InitGame:
     30:00 Exit: Fraglimit hit.
     35:00 ShutdownGame:
-    """, 2, False),
-    ("", 0, False),
-])
-def test_parse_log_file(create_mock_log_file, log_content, expected_game_count, expected_final_state):
+    """,
+            2,
+            False,
+        ),
+        ("", 0, False),
+    ],
+)
+def test_parse_log_file(
+    create_mock_log_file, log_content, expected_game_count, expected_final_state
+):
     mock_file = create_mock_log_file(log_content)
     parser = QuakeLogParser(mock_file)
 
-    result = parser.parse()
+    parser.parse()
 
-    assert result["game_count"] == expected_game_count
-    assert parser.current_game == expected_final_state
+    assert len(parser.games) == expected_game_count
+    assert isinstance(parser.current_game, QuakeLog) == expected_final_state


### PR DESCRIPTION
**Changes summary**

**Features**
 - Use Python `dataclasses` for representing a game
 - Use `python.re` (regexp) for matching text in each log line
 - Add logic to mark when a game started and finished

Tests:
- Use `pytest.mark.parametrize` for input data variation on `Arrange` step
 - Add log fixture files

Configurations:
 - Track `.vscode/` folder on git to standardize configurations (for VS Code users, of course)